### PR TITLE
Added option to pass minimum distance between innovation peaks

### DIFF
--- a/pySPFM/deconvolution/debiasing.py
+++ b/pySPFM/deconvolution/debiasing.py
@@ -1,4 +1,5 @@
 """Debiasing functions for PFM."""
+
 import logging
 
 import numpy as np
@@ -184,7 +185,7 @@ def do_debias_block(hrf, y, estimates_matrix, dist=2):
     return beta_out
 
 
-def debiasing_block(hrf, y, estimates_matrix, n_jobs=4):
+def debiasing_block(hrf, y, estimates_matrix, n_jobs=4, dist=2):
     """Voxelwise block model debiasing workflow.
 
     Parameters
@@ -198,6 +199,8 @@ def debiasing_block(hrf, y, estimates_matrix, n_jobs=4):
         Matrix containing the non-zero coefficients selected as neuronal-related.
     n_jobs : int, optional
         Number of jobs to run in parallel, by default 4
+    dist : int, optional
+        Minimum number of TRs in between of the peaks found, by default 2
 
     Returns
     -------
@@ -216,7 +219,7 @@ def debiasing_block(hrf, y, estimates_matrix, n_jobs=4):
     futures = []
     for voxidx in range(n_voxels):
         fut = delayed_dask(do_debias_block, pure=False)(
-            hrf, y[:, voxidx], estimates_matrix[:, voxidx]
+            hrf, y[:, voxidx], estimates_matrix[:, voxidx], dist
         )
         futures.append(fut)
     debiased = compute(futures)[0]

--- a/pySPFM/workflows/auc_to_estimates.py
+++ b/pySPFM/workflows/auc_to_estimates.py
@@ -183,6 +183,13 @@ def _get_parser():
         default=3,
     )
     optional.add_argument(
+        "--innovation-distance",
+        dest="block_dist",
+        type=int,
+        help=("Minimum number of TRs in between of the peaks found. Default = 2."),
+        default=2,
+    )
+    optional.add_argument(
         "-debug",
         "--debug",
         dest="debug",
@@ -223,6 +230,7 @@ def auc_to_estimates(
     use_bids=False,
     group=False,
     group_distance=3,
+    block_dist=2,
     debug=False,
     quiet=False,
     command_str=None,
@@ -357,7 +365,7 @@ def auc_to_estimates(
     # Solve ordinary least squares problem to calculate estimates
     LGR.info("Calculating estimates...")
     if block_model:
-        estimates_spike = debiasing.debiasing_block(hrf, data_masked, auc_thr, n_jobs)
+        estimates_spike = debiasing.debiasing_block(hrf, data_masked, auc_thr, n_jobs, block_dist)
         fitts = np.dot(hrf, estimates_spike)
     else:
         estimates_spike, fitts = debiasing.debiasing_spike(


### PR DESCRIPTION
<!---
This is a suggested pull request template for pySPFM.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes none.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Adds `--innovation-distance` option to the CLI.
- Adds `block_dist` option to set the minimum distance in TRs between peaks in the innovation signal.
