### PR TITLE
Add option to only use positive estimates in FISTA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,6 @@ jobs:
           command: |
             apt-get update
             apt-get install -yqq make
-            apt-get install -yqq curl
             cp -r /opt/conda/envs/py<< parameters.PYTHON >>_env /opt/miniconda-latest/envs/py<< parameters.PYTHON >>_env
             source activate py<< parameters.PYTHON >>_env
             make unittest
@@ -92,7 +91,6 @@ jobs:
           command: |
             apt-get update
             apt-get install -yqq make
-            apt-get install -yqq curl
             cp -r /opt/conda/envs/py<< parameters.PYTHON >>_env /opt/miniconda-latest/envs/py<< parameters.PYTHON >>_env
             source activate py<< parameters.PYTHON >>_env
             make integrationtest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ jobs:
           command: |
             apt-get update
             apt-get install -yqq make
+            apt-get install -yqq curl
             cp -r /opt/conda/envs/py<< parameters.PYTHON >>_env /opt/miniconda-latest/envs/py<< parameters.PYTHON >>_env
             source activate py<< parameters.PYTHON >>_env
             make unittest
@@ -91,6 +92,7 @@ jobs:
           command: |
             apt-get update
             apt-get install -yqq make
+            apt-get install -yqq curl
             cp -r /opt/conda/envs/py<< parameters.PYTHON >>_env /opt/miniconda-latest/envs/py<< parameters.PYTHON >>_env
             source activate py<< parameters.PYTHON >>_env
             make integrationtest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
             cp -r /opt/conda/envs/py<< parameters.PYTHON >>_env /opt/miniconda-latest/envs/py<< parameters.PYTHON >>_env
             source activate py<< parameters.PYTHON >>_env
             make unittest
-          no_output_timeout: 30m
+          no_output_timeout: 10m
       - codecov/upload:
           file: /tmp/src/pySPFM/coverage.xml
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ jobs:
             cp -r /opt/conda/envs/py<< parameters.PYTHON >>_env /opt/miniconda-latest/envs/py<< parameters.PYTHON >>_env
             source activate py<< parameters.PYTHON >>_env
             make unittest
+          no_output_timeout: 30m
       - codecov/upload:
           file: /tmp/src/pySPFM/coverage.xml
 

--- a/pySPFM/deconvolution/fista.py
+++ b/pySPFM/deconvolution/fista.py
@@ -256,7 +256,7 @@ def fista(
         )
 
         if positive_only:
-            S = jnp.maximum(np.sign(hrf) * S, 0)
+            S = jnp.maximum(np.sign(hrf[0, 0]) * S, 0)
 
     else:
         # Use FISTA with updating lambda
@@ -298,7 +298,7 @@ def fista(
                 S = proximal_operator_lasso_jit(z_ista_S, c_ist * lambda_).block_until_ready()
 
             if positive_only:
-                S = jnp.maximum(np.sign(hrf) * S, 0)
+                S = jnp.maximum(np.sign(hrf[0, 0]) * S, 0)
 
             t_fista, y_fista_S = _fista_update_jit(t_fista, S, S_old)
 

--- a/pySPFM/deconvolution/fista.py
+++ b/pySPFM/deconvolution/fista.py
@@ -256,7 +256,7 @@ def fista(
         )
 
         if positive_only:
-            S = jnp.maximum(S * np.sign(hrf), 0)
+            S = jnp.maximum(np.sign(hrf) * S, 0)
 
     else:
         # Use FISTA with updating lambda
@@ -298,7 +298,7 @@ def fista(
                 S = proximal_operator_lasso_jit(z_ista_S, c_ist * lambda_).block_until_ready()
 
             if positive_only:
-                S = jnp.maximum(S * np.sign(hrf), 0)
+                S = jnp.maximum(np.sign(hrf) * S, 0)
 
             t_fista, y_fista_S = _fista_update_jit(t_fista, S, S_old)
 

--- a/pySPFM/deconvolution/fista.py
+++ b/pySPFM/deconvolution/fista.py
@@ -1,4 +1,5 @@
 """FISTA solver for PFM."""
+
 import logging
 
 import jax
@@ -169,6 +170,7 @@ def fista(
     factor=10,
     lambda_echo=-1,
     use_pylops=False,
+    positive_only=False,
 ):
     """FISTA solver for PFM.
 
@@ -199,6 +201,8 @@ def fista(
         by default -1
     use_pylops : bool, optional
         Use pylops library to solve FISTA instead of using pySPFM's FISTA, by default False
+    positive_only : bool, optional
+        If True, the estimated signal will be forced to be positive, by default False
 
     Returns
     -------
@@ -250,6 +254,10 @@ def fista(
             acceleration="fista",
             show=False,
         )
+
+        if positive_only:
+            S = jnp.maximum(S * np.sign(hrf), 0)
+
     else:
         # Use FISTA with updating lambda
         hrf_trans = hrf.T
@@ -288,6 +296,9 @@ def fista(
                 ).block_until_ready()
             else:
                 S = proximal_operator_lasso_jit(z_ista_S, c_ist * lambda_).block_until_ready()
+
+            if positive_only:
+                S = jnp.maximum(S * np.sign(hrf), 0)
 
             t_fista, y_fista_S = _fista_update_jit(t_fista, S, S_old)
 

--- a/pySPFM/tests/conftest.py
+++ b/pySPFM/tests/conftest.py
@@ -104,6 +104,11 @@ def fista_results(testpath):
 
 
 @pytest.fixture
+def fista_positives(testpath):
+    return fetch_file("9jbas", testpath, "fista_positives.npy")
+
+
+@pytest.fixture
 def coef_path_results(testpath):
     return fetch_file("nxgeq", testpath, "coef_path.npy")
 

--- a/pySPFM/tests/test_fista.py
+++ b/pySPFM/tests/test_fista.py
@@ -15,6 +15,22 @@ def test_fista(sim_data, sim_hrf, fista_results):
     assert np.allclose(estimates, np.load(fista_results, allow_pickle=True), atol=1e-6)
 
 
+def test_fista_positives(sim_data, sim_hrf, fista_results):
+    y = np.load(sim_data, allow_pickle=True)
+    hrf_matrix = np.load(sim_hrf, allow_pickle=True)
+
+    # Run FISTA without pylops
+    estimates, lambda_ = fista.fista(
+        hrf_matrix, y, group=0.2, use_pylops=False, max_iter=50, positive_only=True
+    )
+
+    # Compare estimates
+    assert np.allclose(lambda_, np.repeat(np.array([0.60157822]), y.shape[1], axis=0))
+    assert np.allclose(
+        estimates, np.maximum(np.load(fista_results, allow_pickle=True), 0), atol=1e-6
+    )
+
+
 def test_fista_pylops(sim_data, sim_hrf, pylops_results):
     y = np.load(sim_data, allow_pickle=True)
     hrf_matrix = np.load(sim_hrf, allow_pickle=True)

--- a/pySPFM/tests/test_fista.py
+++ b/pySPFM/tests/test_fista.py
@@ -15,7 +15,7 @@ def test_fista(sim_data, sim_hrf, fista_results):
     assert np.allclose(estimates, np.load(fista_results, allow_pickle=True), atol=1e-6)
 
 
-def test_fista_positives(sim_data, sim_hrf, fista_results):
+def test_fista_positives(sim_data, sim_hrf, fista_positives):
     y = np.load(sim_data, allow_pickle=True)
     hrf_matrix = np.load(sim_hrf, allow_pickle=True)
 
@@ -27,7 +27,7 @@ def test_fista_positives(sim_data, sim_hrf, fista_results):
     # Compare estimates
     assert np.allclose(lambda_, np.repeat(np.array([0.60157822]), y.shape[1], axis=0))
     assert np.allclose(
-        estimates, np.maximum(np.load(fista_results, allow_pickle=True), 0), atol=1e-6
+        estimates, np.maximum(np.load(fista_positives, allow_pickle=True), 0), atol=1e-6
     )
 
 

--- a/pySPFM/workflows/pySPFM.py
+++ b/pySPFM/workflows/pySPFM.py
@@ -299,6 +299,13 @@ def _get_parser():
         default=50,
     )
     optional.add_argument(
+        "--positive",
+        dest="positive_only",
+        action="store_true",
+        help="Force estimated signal to be positive.",
+        default=False,
+    )
+    optional.add_argument(
         "-debug",
         "--debug",
         dest="debug",
@@ -352,6 +359,7 @@ def pySPFM(
     tolerance=1e-6,
     use_bids=False,
     n_surrogates=50,
+    positive_only=False,
     debug=False,
     quiet=False,
     command_str=None,
@@ -424,6 +432,8 @@ def pySPFM(
         header of the output."
     n_surrogates : int, optional
         Number of surrogates to generate for stability selection, by default 50
+    positive_only : bool, optional
+        If True, the estimated signal will be forced to be positive, by default False
     debug : bool, optional
         Logger option for debugging, by default False
     quiet : bool, optional
@@ -613,6 +623,7 @@ def pySPFM(
                         pcg=pcg,
                         factor=factor,
                         lambda_echo=lambda_echo,
+                        positive_only=positive_only,
                     )
                     futures.append(fut)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for pySPFM.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes none.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Adds CLI and API argument to only use positive estimates.
- Adds the condition of positives only to FISTA.
- Uses new output for the positives-only FISTA test.
- Increases no-output timeout to 30m for unit tests.
