### PR TITLE
[FIX] Estimates are no longer zero when using the positives only option

### DIFF
--- a/pySPFM/deconvolution/fista.py
+++ b/pySPFM/deconvolution/fista.py
@@ -296,7 +296,6 @@ def fista(
                 s = proximal_operator_lasso_jit(z_ista_s, c_ist * lambda_).block_until_ready()
 
             if positive_only:
-                breakpoint()
                 s = np.sign(hrf[1, 0]) * jnp.maximum(np.sign(hrf[1, 0]) * s, 0)
 
             t_fista, y_fista_s = _fista_update_jit(t_fista, s, s_old)

--- a/pySPFM/deconvolution/fista.py
+++ b/pySPFM/deconvolution/fista.py
@@ -254,7 +254,7 @@ def fista(
         )
 
         if positive_only:
-            s = jnp.maximum(np.sign(hrf[0, 0]) * s, 0)
+            s = np.sign(hrf[1, 0]) * jnp.maximum(np.sign(hrf[1, 0]) * s, 0)
 
     else:
         # Use FISTA with updating lambda
@@ -296,7 +296,8 @@ def fista(
                 s = proximal_operator_lasso_jit(z_ista_s, c_ist * lambda_).block_until_ready()
 
             if positive_only:
-                s = jnp.maximum(np.sign(hrf[0, 0]) * s, 0)
+                breakpoint()
+                s = np.sign(hrf[1, 0]) * jnp.maximum(np.sign(hrf[1, 0]) * s, 0)
 
             t_fista, y_fista_s = _fista_update_jit(t_fista, s, s_old)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for pySPFM.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #99.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Changes the HRF value used to get the sign from `hrf[0,0]` to `hrf[1,0]` so that the sign is `+1` or `-1`.
- Adds an extra multiplication of the sign after finding the maximum between the estimate that evokes a positive BOLD response and 0. This makes sure that the estimate has the correct sign, i.e., a negative sign in multi-echo data.
