### PR TITLE
[ENH] Add support for the use of regressors in the deconvolution step

### DIFF
--- a/pySPFM/deconvolution/lars.py
+++ b/pySPFM/deconvolution/lars.py
@@ -5,6 +5,8 @@ import logging
 import numpy as np
 from sklearn.linear_model import lars_path
 
+from pySPFM.deconvolution.fista import fista
+
 LGR = logging.getLogger("GENERAL")
 
 
@@ -40,7 +42,7 @@ def select_optimal_lambda(residuals, non_zero_count, n_scans, criterion="bic"):
     return idx_optimal_lambda
 
 
-def solve_regularization_path(x, y, n_lambdas, criterion="bic"):
+def solve_regularization_path(x, y, n_lambdas, criterion="bic", use_fista=False, regressors=None):
     """Solve the regularization path with the LARS algorithm.
 
     Parameters
@@ -53,6 +55,11 @@ def solve_regularization_path(x, y, n_lambdas, criterion="bic"):
         Number of lambdas to be tested
     criterion : str, optional
         Criterion to find the optimal solution, by default "bic"
+    use_fista : bool, optional
+        Whether to use FISTA in favor of LARS to solve the regularization path.
+    regressors : ndarray
+        Matrix with regressors to be included in the deconvolution. Regressors are NOT
+        included in the regularization step. By default None.
 
     Returns
     -------
@@ -72,15 +79,26 @@ def solve_regularization_path(x, y, n_lambdas, criterion="bic"):
     lambdas = np.zeros((n_lambdas,))
 
     # LARS path
-    lambdas_temp, _, coef_path_temp = lars_path(
-        x,
-        np.squeeze(y),
-        method="lasso",
-        Gram=np.dot(x.T, x),
-        Xy=np.dot(x.T, np.squeeze(y)),
-        max_iter=n_lambdas - 1,
-        eps=1e-9,
-    )
+    if use_fista:
+        # Calculate the maximum lambda possible
+        max_lambda = abs(np.dot(x.T, y)).max()
+
+        # Calculate the lambda values in a log scale from 0.05 to 0.95 percent
+        # of the maximum lambda if the maximum lambda is not zero.
+        lambdas = np.geomspace(0.05 * max_lambda, 0.95 * max_lambda, n_lambdas)
+
+        for lambda_id, lambda_val in enumerate(lambdas):
+            coef_path[:, lambda_id] = fista(x, y, lambda_=lambda_val, regressors=regressors)
+    else:
+        lambdas_temp, _, coef_path_temp = lars_path(
+            x,
+            np.squeeze(y),
+            method="lasso",
+            Gram=np.dot(x.T, x),
+            Xy=np.dot(x.T, np.squeeze(y)),
+            max_iter=n_lambdas - 1,
+            eps=1e-9,
+        )
 
     # Store the results
     coef_path[:, : len(lambdas_temp)] = coef_path_temp

--- a/pySPFM/deconvolution/stability_selection.py
+++ b/pySPFM/deconvolution/stability_selection.py
@@ -168,7 +168,7 @@ def _generate_shared_lambdas_space(coefs, lambdas, n_lambdas, n_surrogates):
     return coefs_sorted, lambdas_sorted
 
 
-def stability_selection(hrf_norm, data, n_lambdas, n_surrogates):
+def stability_selection(hrf_norm, data, n_lambdas, n_surrogates, use_fista=False):
     """Stability Selection for deconvolution.
 
     Parameters
@@ -181,6 +181,8 @@ def stability_selection(hrf_norm, data, n_lambdas, n_surrogates):
         Number of lambdas.
     n_surrogates : int
         Number of surrogates.
+    use_fista : bool, optional
+        Whether to use FISTA in favor of LARS to solve the regularization path.
 
     Returns
     -------
@@ -203,7 +205,7 @@ def stability_selection(hrf_norm, data, n_lambdas, n_surrogates):
 
         # Solve LARS
         fut_stability = solve_regularization_path(
-            hrf_norm[subsample_idx, :], data[subsample_idx], n_lambdas, "stability"
+            hrf_norm[subsample_idx, :], data[subsample_idx], n_lambdas, "stability", use_fista
         )
         stability_estimates.append(fut_stability)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for pySPFM.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes none.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Adds the option to run FISTA with regressors to improve the estimation of activity.
- Adds the option to run stability selection with FISTA so that regressors can be used.
