### PR TITLE
[FIX] No TE bug in `hrf_generator`

### DIFF
--- a/pySPFM/deconvolution/hrf_generator.py
+++ b/pySPFM/deconvolution/hrf_generator.py
@@ -33,11 +33,12 @@ class HRFMatrix:
     ):
         # If te values are higher than 1, then assume they are in ms and convert to s
         # If te values are lower than 1, then assume they are in s
-
         if te is not None:
             if max(te) > 1:
                 te = [i / 1000 for i in te]
             self.te = te
+        else:
+            self.te = [0]
 
         self.model = model
         self.block = block

--- a/pySPFM/tests/test_hrf_generator.py
+++ b/pySPFM/tests/test_hrf_generator.py
@@ -19,3 +19,9 @@ def test_HRF_matrix(spm_single_echo, spm_single_echo_block, glover_multi_echo):
     hrf = hrf_object.generate_hrf(tr=1, n_scans=168).hrf_
     hrf_loaded = np.load(glover_multi_echo)
     assert np.allclose(hrf, hrf_loaded)
+
+
+def test_no_te():
+    hrf_object = hrf_generator.HRFMatrix(block=False)
+    hrf = hrf_object.generate_hrf(tr=1, n_scans=168).hrf_
+    assert hrf.shape == (168, 168)


### PR DESCRIPTION
<!---
This is a suggested pull request template for pySPFM.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #72.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Makes `te=[0]` when it is not provided.
- Adds a new test to make sure the error doesn't appear.
