### PR TITLE
[FIX] Path to example images is now in _static

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,7 +21,7 @@ clean:
 html: Makefile
 	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	mkdir -p _build/html/_charts _build/html/_static
-	cp -r charts/* _build/html/_charts/
+	cp -r charts/* _build/html/_static/
 	cp -r _static/* _build/html/_static/
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -71,7 +71,7 @@ data_spc = data_spc/np.sqrt(np.sum(data_spc**2, axis=0))
 Here is a look at the simulated signal:
 
 <div class="image-container">
-    <img src="_charts/simulated_signal.png" alt="Simulated signal">
+    <img src="_static/simulated_signal.png" alt="Simulated signal">
 </div>
 
 ### Spike model
@@ -93,7 +93,7 @@ _, lambda_opt, coef_path, lambdas = solve_regularization_path(hrf, data, n_scans
 The estimates of activity-inducing signal for each value of $\lambda$ in the regularization path are shown on the plot below[^1]. Move the slider to see the effect of the regularization parameter on the estimated coefficients.
 
 <div class="iframe-container">
-    <iframe src="_charts/regularization_figure_spike.html" id="plotly-figure-spike"></iframe>
+    <iframe src="_static/regularization_figure_spike.html" id="plotly-figure-spike"></iframe>
 </div>
 
 You can see how the maximum value of $\lambda$ returns no estimates, while the lowest value overfits the data. The estimated spikes capture the moment the BOLD response starts. Remember that the value of $\lambda$ has to be selected carefully to obtain a good balance between bias and variance.
@@ -117,7 +117,7 @@ _, lambda_opt, coef_path, lambdas = solve_regularization_path(hrf, data_spc, n_s
 Remember that with the block model, the sparsity constraint is applied to the derivative of the activity-inducing signal, which allows us to obtain the innovation signal. These estimates of the innovation signal are visible on the plot below. Move the slider to see the effect of the regularization parameter on the estimated coefficients.
 
 <div class="iframe-container">
-    <iframe src="_charts/regularization_figure_block.html" id="plotly-figure-block"></iframe>
+    <iframe src="_static/regularization_figure_block.html" id="plotly-figure-block"></iframe>
 </div>
 
 You can see that the innovation signal captures the instances where the BOLD response starts and ends. Once again, the value of $\lambda$ has to be selected carefully to obtain a good balance between bias and variance.
@@ -141,7 +141,7 @@ auc = stability_selection(hrf, data_spc, n_lambdas, n_surrogates)
 The AUC time series for the spike model is shown below:
 
 <div class="image-container">
-    <img src="_charts/stability_selection.png" alt="Stability Selection results">
+    <img src="_static/stability_selection.png" alt="Stability Selection results">
 </div>
 
 By definition, the AUC time series cannot have zero values. However, that will only happen if the entire space of the regularization path is explored; i.e., if all the regularization parameters are considered. This means that we still have to apply a threshold to the AUC time series to obtain the final estimates. One way to do this is to select a region of the brain where you do not expect to see any activity, like the deep white matter. You can then use the 95th percentile of the AUC time series in that region as a threshold.
@@ -149,7 +149,7 @@ By definition, the AUC time series cannot have zero values. However, that will o
 Here is what the thresholded AUC time series would look like if we thresholded the AUC time series above with a 0.15 threshold:
 
 <div class="image-container">
-    <img src="_charts/stability_selection_thresholded.png" alt="Thresholded Stability Selection results">
+    <img src="_static/stability_selection_thresholded.png" alt="Thresholded Stability Selection results">
 </div>
 
 [^1]: To help visualize the results, the clean (noiseless) simulation of the BOLD data is shown in all figures.


### PR DESCRIPTION
<!---
This is a suggested pull request template for pySPFM.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes none.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Moves example images to _static folder
- Updates the paths
